### PR TITLE
Loki: add optional formatter to Loki Appender

### DIFF
--- a/lib/src/remote/loki_appender.dart
+++ b/lib/src/remote/loki_appender.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:intl/intl.dart';
+import 'package:logging_appenders/logging_appenders.dart';
 import 'package:logging_appenders/src/internal/dummy_logger.dart';
 import 'package:logging_appenders/src/remote/base_remote_appender.dart';
 
@@ -16,22 +17,23 @@ class LokiApiAppender extends BaseDioLogSender {
     required this.username,
     required this.password,
     required this.labels,
-  })   : labelsString = '{' +
-            labels.entries
-                .map((entry) => '${entry.key}="${entry.value}"')
-                .join(',') +
-            '}',
-        authHeader = 'Basic ' +
-            base64
-                .encode(utf8.encode([username, password].join(':')))
-                .toString();
+    LogRecordFormatter? formatter,
+  }) : super(formatter: formatter) {
+    labelsString = '{' +
+        labels.entries
+            .map((entry) => '${entry.key}="${entry.value}"')
+            .join(',') +
+        '}';
+    authHeader = 'Basic ' +
+        base64.encode(utf8.encode([username, password].join(':'))).toString();
+  }
 
   final String server;
   final String username;
   final String password;
-  final String authHeader;
+  late final String authHeader;
   final Map<String, String> labels;
-  final String labelsString;
+  late final String labelsString;
 
   static final DateFormat _dateFormat =
       DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
@@ -50,8 +52,9 @@ class LokiApiAppender extends BaseDioLogSender {
   @override
   Future<void> sendLogEventsWithDio(List<LogEntry> entries,
       Map<String, String> userProperties, CancelToken cancelToken) {
-    final jsonObject =
-        LokiPushBody([LokiStream(labelsString, entries)]).toJson();
+    final jsonObject = LokiPushBody(
+      [LokiStream(labelsString, entries)],
+    ).toJson();
     final jsonBody = json.encode(jsonObject, toEncodable: (dynamic obj) {
       if (obj is LogEntry) {
         return {


### PR DESCRIPTION
Unlike the rest of appenders, the `LokiApiAppender` did not have the option to add a formatter as a parameter to convert `LogRecord` to strings so the formatting could not be changed. This PR adds the formatter as an optional named parameter  which adds retrocompatibility for people already using this appender.