### PR TITLE
General Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.0
+* Adjusted model to match the latest version of the Loki API
+* Updated deprecated push endpoint for Loki
+* Sending messages sorted by log levels, which makes filtering for it in Loki easier/possible
+* Adding a configuration model for Loki
+  * Can now choose between HTTP (e.g. for IP addresses) and HTTPS 
+  * Does not require Authentification anymore
+
 ## 1.3.1
 
 * Default formatter: add support for printing `cause` of [JsonUnsupportedObjectError]

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   meta:
     dependency: transitive
     description:

--- a/lib/logging_appenders.dart
+++ b/lib/logging_appenders.dart
@@ -11,5 +11,8 @@ export 'src/print_appender.dart' show PrintAppender;
 export 'src/remote/gelf_http_appender.dart' show GelfHttpAppender;
 export 'src/remote/logzio_appender.dart' show LogzIoApiAppender;
 export 'src/remote/loki_appender.dart' show LokiApiAppender;
+export 'src/remote/loki_connection_type.dart' show LokiConnectionType;
+export 'src/remote/loki_auth_configuration.dart' show LokiAuthConiguration;
+export 'src/remote/loki_configuration.dart' show LokiConfiguration;
 export 'src/rotating_file_appender.dart'
     show AsyncInitializingLogHandler, RotatingFileAppender;

--- a/lib/src/remote/loki_appender.dart
+++ b/lib/src/remote/loki_appender.dart
@@ -3,44 +3,22 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:intl/intl.dart';
 import 'package:logging_appenders/src/internal/dummy_logger.dart';
 import 'package:logging_appenders/src/remote/base_remote_appender.dart';
+import 'package:logging_appenders/src/remote/loki_configuration.dart';
 
 final _logger = DummyLogger('logging_appenders.loki_appender');
 
 /// Appender used to push logs to [Loki](https://github.com/grafana/loki).
 class LokiApiAppender extends BaseDioLogSender {
   LokiApiAppender({
-    required this.server,
-    required this.username,
-    required this.password,
-    required this.labels,
-  })  : labelsString =
-            '{${labels.entries.map((entry) => '${entry.key}="${entry.value}"').join(',')}}',
-        authHeader = 'Basic ${base64.encode(utf8.encode([
-          username,
-          password
-        ].join(':')))}';
+    required this.configuration
+  }) : authHeader = configuration.authConfiguration?.basicAuthHeader ?? '';
 
-  final String server;
-  final String username;
-  final String password;
+  final LokiConfiguration configuration;
   final String authHeader;
-  final Map<String, String> labels;
-  final String labelsString;
-
-  static final DateFormat _dateFormat =
-      DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
   late final Dio _client = Dio();
-
-  static String _encodeLineLabelValue(String value) {
-    if (value.contains(' ')) {
-      return json.encode(value);
-    }
-    return value;
-  }
 
   @override
   Future<void> dispose() async {
@@ -51,41 +29,43 @@ class LokiApiAppender extends BaseDioLogSender {
   @override
   Future<void> sendLogEventsWithDio(List<LogEntry> entries,
       Map<String, String> userProperties, CancelToken cancelToken) {
-    final jsonObject =
-        LokiPushBody([LokiStream(labelsString, entries)]).toJson();
+    var levels = entries.map((element) => element.logLevel).toSet();
+    List<LokiStream> streams = [];
+    for (var level in levels) {
+      var newHeaders = Map<String, String>.from(configuration.labels)
+        ..addAll({'level': level.name});
+      streams.add(LokiStream(
+          newHeaders, entries.where((e) => e.logLevel == level).toList()));
+    }
+    final jsonObject = LokiPushBody(streams);
     final jsonBody = json.encode(jsonObject, toEncodable: (dynamic obj) {
       if (obj is LogEntry) {
-        return {
-          'ts': _dateFormat.format(obj.ts.toUtc()),
-          'line': [
-            obj.lineLabels.entries
-                .map((entry) =>
-                    '${entry.key}=${_encodeLineLabelValue(entry.value)}')
-                .join(' '),
-            obj.line,
-          ].join(' - ')
-        };
+        return [
+          '${obj.ts.microsecondsSinceEpoch * 1000}',
+          obj.line,
+        ];
       }
       return obj.toJson();
     });
     return _client
         .post<dynamic>(
-          'https://$server/api/prom/push',
-          cancelToken: cancelToken,
-          data: jsonBody,
-          options: Options(
-            headers: <String, String>{
-              HttpHeaders.authorizationHeader: authHeader,
-            },
-            contentType: ContentType(
-                    ContentType.json.primaryType, ContentType.json.subType)
-                .value,
-          ),
-        )
+      '${configuration.connectionType.value}://${configuration
+          .server}/loki/api/v1/push',
+      cancelToken: cancelToken,
+      data: jsonBody,
+      options: Options(
+        headers: <String, String>{
+          HttpHeaders.authorizationHeader: authHeader,
+        },
+        contentType: ContentType(
+            ContentType.json.primaryType, ContentType.json.subType)
+            .value,
+      ),
+    )
         .then(
           (response) => Future<void>.value(null),
 //      _logger.finest('sent logs.');
-        )
+    )
         .catchError((Object err, StackTrace stackTrace) {
       String? message;
       if (err is DioException) {
@@ -105,18 +85,19 @@ class LokiPushBody {
 
   final List<LokiStream> streams;
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{
         'streams':
-            streams.map((stream) => stream.toJson()).toList(growable: false),
+        streams.map((stream) => stream.toJson()).toList(growable: false),
       };
 }
 
 class LokiStream {
   LokiStream(this.labels, this.entries);
 
-  final String labels;
+  final Map<String, String> labels;
   final List<LogEntry> entries;
 
   Map<String, dynamic> toJson() =>
-      <String, dynamic>{'labels': labels, 'entries': entries};
+      <String, dynamic>{'stream': labels, 'values': entries};
 }

--- a/lib/src/remote/loki_auth_configuration.dart
+++ b/lib/src/remote/loki_auth_configuration.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+
+class LokiAuthConiguration {
+  LokiAuthConiguration({
+    required this.username,
+    required this.password,
+  });
+
+  final String username;
+  final String password;
+
+  String get basicAuthHeader =>
+      'Basic ${base64Encode(utf8.encode('$username:$password'))}';
+}

--- a/lib/src/remote/loki_configuration.dart
+++ b/lib/src/remote/loki_configuration.dart
@@ -1,0 +1,16 @@
+import 'package:logging_appenders/src/remote/loki_auth_configuration.dart';
+import 'package:logging_appenders/src/remote/loki_connection_type.dart';
+
+class LokiConfiguration {
+  LokiConfiguration({
+    required this.server,
+    required this.connectionType,
+    required this.authConfiguration,
+    required this.labels,
+  });
+
+  final String server;
+  final LokiConnectionType connectionType;
+  final LokiAuthConiguration? authConfiguration;
+  final Map<String, String> labels;
+}

--- a/lib/src/remote/loki_connection_type.dart
+++ b/lib/src/remote/loki_connection_type.dart
@@ -1,0 +1,7 @@
+enum LokiConnectionType {
+  http('http'),
+  https('https');
+  final String value;
+
+  const LokiConnectionType(this.value);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logging_appenders
 description: Logging appenders for the dart logging package for print, file and remote (logz, loki, graylog (gelf)).
-version: 1.3.1
+version: 1.4.0
 homepage: https://github.com/hpoul/dart_logging_appenders/
 screenshots:
   - description: Colored console output


### PR DESCRIPTION
* Adjusted model to match the latest version of the Loki API
* Updated deprecated push endpoint for Loki
* Sending messages sorted by log levels, which makes filtering for it in Loki easier/possible
* Adding a configuration model for Loki
  * Can now choose between HTTP (e.g. for IP addresses) and HTTPS 
  * Does not require Authentification anymore