### PR TITLE
Draft: Fix rotating under heavy load on Windows

### DIFF
--- a/lib/src/rotating_file_appender.dart
+++ b/lib/src/rotating_file_appender.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: implementation_imports
+
 import 'dart:async';
 import 'dart:io';
 
@@ -69,7 +71,6 @@ class RotatingFileAppender extends BaseLogAppender {
   IOSink _getOpenOutputFileSink() =>
       _outputFileSink ??= _outputFile.openWrite(mode: FileMode.append)
         ..done.catchError((Object error, StackTrace stackTrace) {
-          print('error while writing to logging file.');
           _logger.warning(
               'Error while writing to logging file.', error, stackTrace);
           return Future<dynamic>.error(error, stackTrace);
@@ -78,16 +79,29 @@ class RotatingFileAppender extends BaseLogAppender {
   static int id = 0;
   final int instanceId = id++;
 
+  final List<String> _rotateBuffer = <String>[];
+  bool _inFlushAndClose = false;
+
   @override
   void handle(LogRecord record) {
     if (record.loggerName == _logger.fullName) {
       // ignore my own log messages.
       return;
     }
+    final rotating = _nextRotateCheck == null || _inFlushAndClose;
+    if (rotating) {
+      _rotateBuffer.add(formatter.format(record));
+      return;
+    } else if (_rotateBuffer.isNotEmpty) {
+      final sink = _getOpenOutputFileSink();
+      for (final line in _rotateBuffer) {
+        sink.writeln(line);
+      }
+      _rotateBuffer.clear();
+    }
     try {
       _getOpenOutputFileSink().writeln(formatter.format(record));
     } catch (error, stackTrace) {
-      print('error while writing log $error $stackTrace');
       _logger.warning('Error while writing log.', error, stackTrace);
       _closeAndFlush();
       // try once more.
@@ -114,42 +128,37 @@ class RotatingFileAppender extends BaseLogAppender {
     }
     _nextRotateCheck = null;
     try {
+      // Rotate the file if it can be read & reached its size limit
+      var rotate = false;
       try {
-        final length = await File(_outputFile.path).length();
-        if (length < rotateAtSizeBytes) {
-          return false;
+        if (await File(_outputFile.path).length() > rotateAtSizeBytes) {
+          rotate = true;
         }
-      } on FileSystemException catch (_) {
-        // if .length() throws an error, ignore it.
-        return false;
       } catch (e, stackTrace) {
         _logger.warning('Error while checking file length.', e, stackTrace);
-        rethrow;
+      }
+      if (!rotate) {
+        return false;
       }
 
-      Future<void>? flushFuture;
-      for (var i = keepRotateCount - 1; i >= 0; i--) {
+      // Rotate files that are not currently used
+      for (var i = keepRotateCount - 1; i >= 1; i--) {
         final file = File(_fileNameForRotation(i));
         if (file.existsSync()) {
-          try {
-            await file.rename(_fileNameForRotation(i + 1));
-          } on FileSystemException catch (_) {
-            if (i == 0) {
-              // open file can't be renamed on Windows, so close file and retry
-              flushFuture = _closeAndFlush();
-              await flushFuture;
-              await file.rename(_fileNameForRotation(i + 1));
-            } else {
-              rethrow;
-            }
-          }
+          await file.rename(_fileNameForRotation(i + 1));
         }
       }
 
-      // initiate flush if not already running
-      flushFuture ??= _closeAndFlush();
+      // Close file before renaming the last, currently-in-use file
+      await _closeAndFlush();
+
+      // Rename the last file
+      final file = File(_fileNameForRotation(0));
+      if (file.existsSync()) {
+        await file.rename(_fileNameForRotation(1));
+      }
+
       handle(LogRecord(Level.INFO, 'Rotated log.', '_'));
-      await flushFuture;
       return true;
     } finally {
       _nextRotateCheck = clock.now().add(rotateCheckInterval);
@@ -159,13 +168,26 @@ class RotatingFileAppender extends BaseLogAppender {
   Future<void> _closeAndFlush() async {
     _closeAndFlushTimer?.cancel();
     _closeAndFlushTimer = null;
+
+    // It can happen that the first log entries are put in a buffer without the sink being opened.
+    // Open the sink in this case, so buffered data gets written and flushed.
+    if (_rotateBuffer.isNotEmpty) _getOpenOutputFileSink();
+
     if (_outputFileSink != null) {
       try {
         final oldSink = _outputFileSink!;
+        for (final line in _rotateBuffer) {
+          oldSink.writeln(line);
+        }
+        _rotateBuffer.clear();
+
         _outputFileSink = null;
+        _inFlushAndClose = true;
         await oldSink.flush();
         await oldSink.close();
+        _inFlushAndClose = false;
       } catch (e, stackTrace) {
+        _inFlushAndClose = false;
         _logger.warning('Error while flushing, closing stream.', e, stackTrace);
       }
     }

--- a/test/rotating_file_appender_test.dart
+++ b/test/rotating_file_appender_test.dart
@@ -71,6 +71,38 @@ void main() {
     expect(appender.getAllLogFiles(), hasLength(1));
     appender.handle(_logRecord('baz'));
     await Future<dynamic>.delayed(const Duration(milliseconds: 100));
+    await appender.forceFlush();
+    expect(appender.getAllLogFiles(), hasLength(2));
+    expect(File(logFile).existsSync(), true);
+    expect(File('$logFile.1').existsSync(), true);
+    appender.handle(_logRecord('bar'));
+//    }, initialTime: DateTime(2018));
+    await Future<dynamic>.delayed(const Duration(milliseconds: 100));
+    await _debugFiles(dir);
+    await appender.dispose();
+  });
+
+  tempDirTest('Check logging while rotating', (dir) async {
+    final logFile = path.join(dir.path, 'app.log');
+//    fakeAsync((async) {
+    print('clock: ${clock.now()} XXX ${_logRecord('blubb')}');
+
+    final appender = RotatingFileAppender(
+      baseFilePath: logFile,
+      rotateAtSizeBytes: 500,
+      rotateCheckInterval: Duration(milliseconds: 100),
+    );
+    expect(File(logFile).existsSync(), false);
+    expect(File('$logFile.1').existsSync(), false);
+    for (int i = 0; i < 10000; i++) {
+      appender.handle(_logRecord('foo$i'));
+      appender.handle(_logRecord('bar$i'));
+    }
+    await appender.forceFlush();
+    expect(appender.getAllLogFiles(), hasLength(1));
+    appender.handle(_logRecord('baz'));
+    await Future<dynamic>.delayed(const Duration(milliseconds: 100));
+    await appender.forceFlush();
     expect(appender.getAllLogFiles(), hasLength(2));
     expect(File(logFile).existsSync(), true);
     expect(File('$logFile.1').existsSync(), true);


### PR DESCRIPTION
Turns out that https://github.com/hpoul/dart_logging_appenders/pull/15 doesn't fully fix rotating files on Windows: When there are multiple new log entries during the async _closeAndFlush, I get broken log files + unhandled exceptions for the renaming, because the file that should be deleted is implicitly re-opened after closing.
So I'm using a different approach here: Log to a buffer, and write the buffer with the next log entry after the renaming or when closing.
This PR needs a better test case, and I'm not sure if the approach is suitable for non-windows platforms - where the buffering is not needed. (I always find it fascinating that you can write to files that have already been deleted/renamed on Linux and the deletion is then performed with the last file closed...)
Maybe a solution here would be to split out a base class and have platform-specific implementations?
Anyhow, I'll go on here after maintainer feedback: What kind of solution would likely be accepted?