### PR TITLE
Add support for `Bearer` token to the Grafana Loki appender

### DIFF
--- a/lib/src/remote/loki_appender.dart
+++ b/lib/src/remote/loki_appender.dart
@@ -13,8 +13,8 @@ final _logger = DummyLogger('logging_appenders.loki_appender');
 class LokiApiAppender extends BaseDioLogSender {
   LokiApiAppender({
     required this.server,
-    required this.username,
-    required this.password,
+    required username,
+    required password,
     required this.labels,
   })  : labelsString =
             '{${labels.entries.map((entry) => '${entry.key}="${entry.value}"').join(',')}}',
@@ -23,9 +23,15 @@ class LokiApiAppender extends BaseDioLogSender {
           password
         ].join(':')))}';
 
+  LokiApiAppender.withBearer({
+    required this.server,
+    required bearerToken,
+    required this.labels,
+  })  : labelsString =
+            '{${labels.entries.map((entry) => '${entry.key}="${entry.value}"').join(',')}}',
+        authHeader = 'Bearer $bearerToken';
+
   final String server;
-  final String username;
-  final String password;
   final String authHeader;
   final Map<String, String> labels;
   final String labelsString;


### PR DESCRIPTION
This is necessary when using Grafana Cloud.